### PR TITLE
Move sending chat to Discord to a seperate thread

### DIFF
--- a/src/main/java/net/duckycraft/server_tools/event/ChatEvent.java
+++ b/src/main/java/net/duckycraft/server_tools/event/ChatEvent.java
@@ -24,6 +24,12 @@ public class ChatEvent implements Listener {
         }
 
         String message = event.getMessage(); // Getting the message
-        BOT.sendMessage(message, event.getPlayer()); // Sending the message to discord
+        new Thread(() -> {
+            try {
+                BOT.sendMessage(message, event.getPlayer());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }).start(); // Sending the message to discord
     }
 }


### PR DESCRIPTION
Remove the delay for chat to be broadcasted to all players while the Discord bot is sending the message or downloading the player's Minecraft skin face